### PR TITLE
Create milestone if not already exists

### DIFF
--- a/backport
+++ b/backport
@@ -154,6 +154,11 @@ if [ -n "$ORIGINAL_PR_NUMBER" ]; then
     LABELS_ARG=(--label "$LABELS")
   fi
 fi
+
+log_info "Creating new milestone if not exists..."
+gh extension install valeriobelli/gh-milestone
+gh milestone list --query "$SUFFIX" | grep -q "No milestones found" && gh milestone create --title "$SUFFIX"
+
 log_info "Creating new PR..."
 gh pr create --base "$BASE_BRANCH" --title "$NEW_COMMIT_MSG" \
   --body "Backport of $ORIGINAL_PR_URL$(echo -e "\n\n")$PR_BODY" \


### PR DESCRIPTION
The script will create a pull request, assigning a milestone derived from the target branch - but if there is no existing milestone for this, the script fails:
```
could not add to milestone 'v5': 'v5' not found
```

This change will create a new milestone if required - GitHub's CLI does not support this so an additional extension must be used.